### PR TITLE
Add specification for exporter user-agent names.

### DIFF
--- a/Common.md
+++ b/Common.md
@@ -1,0 +1,18 @@
+# Common Exporter Behavior
+
+This document describes behavior that is common to all New Relic exporters.
+
+# User-Agent values
+
+Each exporter **MUST** report an identifying string and version as part of the `User-Agent` header when sending data to New Relic.
+
+The `User-Agent` values are always in the format `<author>-<language>-<exporter_name>`.  For New Relic exporters, the author is `NewRelic`.
+
+Language names are title cased.
+
+| Exporter | exporter_name | Example User Agent |
+| -------- | ------------- | ------------------ |
+| [opencensus](opencensus) | `OpenCensus` | `NewRelic-Python-OpenCensus/0.1.0` |
+| [micrometer](micrometer) | `Micrometer` | `NewRelic-Java-Micrometer/0.1.0` |
+| [kamon](kamon) | `Kamon` | `NewRelic-Java-Kamon/0.1.0` |
+| [dropwizard](dropwizard) | `DropWizard` | `NewRelic-Java-DropWizard/0.1.0` |

--- a/Common.md
+++ b/Common.md
@@ -6,13 +6,17 @@ This document describes behavior that is common to all New Relic exporters.
 
 Each exporter **MUST** report an identifying string and version as part of the `User-Agent` header when sending data to New Relic.
 
-The `User-Agent` values are always in the format `<author>-<language>-<exporter_name>`.  For New Relic exporters, the author is `NewRelic`.
+These values should be appended using the [add_version_info API](https://github.com/newrelic/newrelic-telemetry-sdk-specs/blob/be844b5ca5044c0f80b037812de7498b3663ae34/communication.md#user-agent) described in the telemetry SDK specification.
+
+The `User-Agent` values that are appended are always in the format `<author>-<language>-<exporter_name>`.  For New Relic exporters, the author is `NewRelic`.
 
 Language names are title cased.
 
-| Exporter | exporter_name | Example User Agent |
+| Exporter | exporter_name | Example Value Appended to the User-Agent |
 | -------- | ------------- | ------------------ |
 | [opencensus](opencensus) | `OpenCensus` | `NewRelic-Python-OpenCensus/0.1.0` |
 | [micrometer](micrometer) | `Micrometer` | `NewRelic-Java-Micrometer/0.1.0` |
 | [kamon](kamon) | `Kamon` | `NewRelic-Java-Kamon/0.1.0` |
 | [dropwizard](dropwizard) | `DropWizard` | `NewRelic-Java-DropWizard/0.1.0` |
+
+A full `User-Agent` example might look like `NewRelic-Python-TelemetrySDK/0.2.3 NewRelic-Python-OpenCensus/0.1.0`.


### PR DESCRIPTION
The telemetry SDK specifications introduced the ability to append product names and versions to the SDK's base user agent string (https://github.com/newrelic/newrelic-telemetry-sdk-specs/pull/8).

In this PR, we define a specification for unified user-agent strings based on the exporter product in use.