### PR TITLE
Move common attribute patterns to Common.md

### DIFF
--- a/Common.md
+++ b/Common.md
@@ -2,6 +2,26 @@
 
 This document describes behavior that is common to all New Relic exporters.
 
+<!-- TOC -->
+
+- [User-Agent values](#user-agent-values)
+- [Attributes](#attributes)
+    - [Instrumentation](#instrumentation)
+        - [`instrumentation.provider`](#instrumentationprovider)
+        - [`instrumentation.name`](#instrumentationname)
+        - [`instrumentation.version`](#instrumentationversion)
+    - [Collector](#collector)
+        - [`collector.name`](#collectorname)
+        - [`collector.version`](#collectorversion)
+    - [Source Kind](#source-kind)
+        - [`host.hostname`](#hosthostname)
+        - [`service.name`](#servicename)
+        - [`app.name`](#appname)
+            - [`device.model`](#devicemodel)
+        - [`db.name`](#dbname)
+
+<!-- /TOC -->
+
 ## User-Agent values
 
 Each exporter MUST report an identifying string and version as part of the `User-Agent` header when sending data to New Relic.

--- a/Common.md
+++ b/Common.md
@@ -71,11 +71,16 @@ See the related sub-section for more information.
 
 ### Instrumentation
 
-Instrumentation is the toolset used to make measurements of a system's state.
-The instruments making up the instrumentation take the form of library of code, a platform, or a coding language builtin.
-From the exporter's perspective, instrumentation is the thing that sends it measurements to export.
+Instruments are used to make measurements of a computing system.
+The collective application of a set of instruments to comprehensively monitor a computing system is the instrumentation.
 
-Including attributes to identify not only what instrumentation is used but also what code is being instrumented is crucial for interoperability between telemetry systems and the New Relic platform.
+For example:
+
+- Instrumentation for an HTTP library might be the dedicated code in the library that measure its performance (e.g. latency, throughput, errors).
+- Instrumentation for a cluster of Kubernetes pods might be the health check probes.
+- Instrumentation for a computer's CPU might be the embedded sensors measuring its physical state (e.g temperature, speed, power).
+
+Including attributes to identify what instrumentation is used is crucial for interoperability between telemetry systems and the New Relic platform.
 
 #### `instrumentation.provider`
 

--- a/Common.md
+++ b/Common.md
@@ -109,6 +109,8 @@ Example values of this attribute are:
 
 All exported measurements SHOULD contain an `instrumentation.version` attribute set to the version of the instrumentation if the instrumentation provider expose this information, otherwise it SHOULD be omitted.
 
+For libraries, this is the version of the _instrumentation_, not the version of the library being instrumented.
+
 Example values of this attribute are:
 
 * `v0.1.0`

--- a/Common.md
+++ b/Common.md
@@ -17,7 +17,9 @@ This document describes behavior that is common to all New Relic exporters.
         - [`host.hostname`](#hosthostname)
         - [`service.name`](#servicename)
         - [`app.name`](#appname)
+            - [`mobileApp.name`](#mobileappname)
             - [`device.model`](#devicemodel)
+            - [`browserApp.name`](#browserappname)
         - [`db.name`](#dbname)
 
 <!-- /TOC -->
@@ -43,9 +45,9 @@ A full `User-Agent` example might look like `NewRelic-Python-TelemetrySDK/0.2.3 
 
 ## Attributes
 
-The origins of telemetry exported to New Relic needs to be identifiable in order for it to be useful.
-Being able to identify what generated, measured, collected, and transmitted telemetry to New Relic is essential to providing a curated customer experience.
-This section describes the attributes are used to identify these dimensions of the telemetry origins.
+The origins of measurements exported to New Relic needs to be identifiable in order for them to be useful.
+Identify what generated, measured, collected, and transmitted measurements to New Relic is essential in providing the curated experience customers expect.
+This section describes the attributes that are used to serve this purpose.
 
 The following table is an overview for quick reference of all the attributes defined in the following sub-sections.
 
@@ -59,22 +61,25 @@ The following table is an overview for quick reference of all the attributes def
 | `host.hostname` | REQUIRED† |
 | `service.name` | REQUIRED† |
 | `app.name` | REQUIRED† |
+| `mobileApp.name` | REQUIRED† |
+| `device.model` | RECOMMENDED† |
+| `browserApp.name` | REQUIRED† |
 | `db.name` | REQUIRED† |
 
-†: REQUIRED only if annotating an applicable telemetry source.
+†: applies only if annotating an applicable telemetry source.
 See the related sub-section for more information.
 
 ### Instrumentation
 
-Instrumentation is the toolset used to measure telemetry.
-This instrumentation usually comes in the form of a library of code, platform, or coding language builtin and provides different instruments to measure the state of a computer program.
-This instrumentation is from what the exporter exports.
+Instrumentation is the toolset used to make measurements of a system's state.
+The instruments making up the instrumentation take the form of library of code, a platform, or a coding language builtin.
+From the exporter's perspective, instrumentation is the thing that sends it measurements to export.
 
-Including attributes to identify not only what instrumentation is used but also what code is being instrumented is crucial for interoperability between exporters and the New Relic platform.
+Including attributes to identify not only what instrumentation is used but also what code is being instrumented is crucial for interoperability between telemetry systems and the New Relic platform.
 
 #### `instrumentation.provider`
 
-All exported telemetry MUST contain an `instrumentation.provider` attribute that identifies the provider of instrumentation.
+All exported measurements MUST contain an `instrumentation.provider` attribute that identifies the provider of instrumentation.
 
 Example values of this attribute are:
 
@@ -86,8 +91,8 @@ Example values of this attribute are:
 
 #### `instrumentation.name`
 
-All exported telemetry SHOULD contain an `instrumentation.name` attribute that identifies the code that is being instrumented.
-This would be the framework, library, or application that uses the instrumentation to report telemetry.
+All exported measurements SHOULD contain an `instrumentation.name` attribute that identifies the code that is being instrumented if the instrumentation provider exposes this information, otherwise it SHOULD be omitted.
+This would be the framework, library, or application that uses the instrumentation to report measurements.
 
 Example values of this attribute are:
 
@@ -97,8 +102,7 @@ Example values of this attribute are:
 
 #### `instrumentation.version`
 
-All exported telemetry SHOULD contain an `instrumentation.version` attribute that identifies the version of the instrumentation.
-This will be defined by the instrumentation provider.
+All exported measurements SHOULD contain an `instrumentation.version` attribute set to the version of the instrumentation if the instrumentation provider expose this information, otherwise it SHOULD be omitted.
 
 Example values of this attribute are:
 
@@ -108,19 +112,16 @@ Example values of this attribute are:
 
 ### Collector
 
-Telemetry sent to New Relic is often produced by many collocated sources.
-Given the close proximity these telemetry sources can have, it can be advantageous to unify the transmission of this telemetry to New Relic.
-This reduces network overhead and can simplify the design of system architectures.
+Identifying what collected and transmitted the measurements of a system is important to know.
+It allows the New Relic platform to inform customers what telemetry systems were used to transmit their data, something that can help debug issues and provide insight into data flows.
 
-Being able to backtrack identity what collector was the ultimate transmitter of telemetry to New Relic is often useful.
-It can help debug issues and provide context of data flows.
+A collector can be as simple as the exporter itself, or as complex as a hierarchical system of proxies.
+Regardless of the complexity or simplicity of the collectors, the measurements they transmit need to identify what collector was the ultimate transmitter.
 The following attributes are used to make this identification possible.
 
 #### `collector.name`
 
-All exported telemetry SHOULD contain an `collector.name` attribute that identifies the name of the code that collected the telemetry.
-This value SHOULD be overwritten if telemetry is proxied.
-Otherwise, this will be the exporter name.
+If the exporter is transmitting to New Relic directly than all exported measurements SHOULD contain a `collector.name` attribute set to the name of the exporter, otherwise it SHOULD be omitted.
 
 Example values of this attribute are:
 
@@ -129,9 +130,7 @@ Example values of this attribute are:
 
 #### `collector.version`
 
-All exported telemetry SHOULD contain an `collector.version` attribute that identifies the version of the collector.
-This value SHOULD be overwritten if telemetry is proxied.
-Otherwise, this will be the exporter version.
+If the exporter is transmitting to New Relic directly than all exported measurements SHOULD contain a `collector.version` attribute set to the version of the exporter, otherwise it SHOULD be omitted.
 
 Example values of this attribute are:
 
@@ -141,29 +140,37 @@ Example values of this attribute are:
 
 ### Source Kind
 
-Clearly identifying what kind of system produced the telemetry sent to New Relic is crucial to do.
-A core feature New Relic offers customers is a curated observability experience and it is not possible to provide this without this identification.
+A core feature of the New Relic platform is providing a curated observability experience.
+This is only possible to provide if telemetry includes information about what kind of system it is measuring.
 
-The following attributes are used to identify the kind of system for which an exporter exports telemetry.
-All exported telemetry MUST include at least one of the following attributes and MAY include more than one.
+The following attributes are used to identify the kind of the measured system.
+All exported measurements MUST include at least one of the following attributes and MAY include more than one.
 
 #### `host.hostname`
 
-All telemetry exported for a host system running an application MUST contain a `host.hostname` attribute that uniquely identifies that host.
-Other kinds of telemetry exported MAY also contain this attribute as this can be helpful to describe the telemetry origin.
+All measurements exported for a host system MUST contain a `host.hostname` attribute that uniquely identifies that host.
+Measurements for other kinds of systems MAY also contain this attribute as it can be helpful in describing their origins.
 
 #### `service.name`
 
-All telemetry exported for a generic computer program MUST contain a `service.name` attribute that identifies the name of the program.
+All measurements exported for a generic computer program (not a mobile or browser application) MUST contain a `service.name` attribute set to the name of the program.
 
 #### `app.name`
 
-All telemetry exported for a mobile or browser application MUST contain an `app.name` attribute that identifies the application.
+All measurements exported for a mobile or browser application MUST contain an `app.name` attribute set to the name of the application.
+
+##### `mobileApp.name`
+
+All measurements exported for a mobile application MUST contain an `mobileApp.name` attribute set to the name of the mobile application.
 
 ##### `device.model`
 
-All telemetry exported for a mobile application MUST contain an `device.model` attribute that identifies the mobile device model.
+All measurements exported for a mobile application SHOULD contain a `device.model` attribute set to the mobile device model.
+
+##### `browserApp.name`
+
+All measurements exported for a browser application MUST contain an `browserApp.name` attribute set to the name of the browser application.
 
 #### `db.name`
 
-All telemetry exported for a database MUST contain an `db.name` attribute that identifies the database name.
+All measurements exported for a database MUST contain an `db.name` attribute set to the database name.

--- a/Common.md
+++ b/Common.md
@@ -47,7 +47,7 @@ The origins of telemetry exported to New Relic needs to be identifiable in order
 Being able to identify what generated, measured, collected, and transmitted telemetry to New Relic is essential to providing a curated customer experience.
 This section describes the attributes are used to identify these dimensions of the telemetry origins.
 
-The following table is an overview for quick reference all the attributes defined in the following sub-sections.
+The following table is an overview for quick reference of all the attributes defined in the following sub-sections.
 
 | Attribute | REQUIRED/RECOMMENDED/OPTIONAL |
 | --------- | ----------------------------- |

--- a/Common.md
+++ b/Common.md
@@ -2,9 +2,9 @@
 
 This document describes behavior that is common to all New Relic exporters.
 
-# User-Agent values
+## User-Agent values
 
-Each exporter **MUST** report an identifying string and version as part of the `User-Agent` header when sending data to New Relic.
+Each exporter MUST report an identifying string and version as part of the `User-Agent` header when sending data to New Relic.
 
 These values should be appended using the [add_version_info API](https://github.com/newrelic/newrelic-telemetry-sdk-specs/blob/be844b5ca5044c0f80b037812de7498b3663ae34/communication.md#user-agent) described in the telemetry SDK specification.
 
@@ -20,3 +20,130 @@ Language names are title cased.
 | [dropwizard](dropwizard) | `DropWizard` | `NewRelic-DropWizard-Exporter/0.1.0` |
 
 A full `User-Agent` example might look like `NewRelic-Python-TelemetrySDK/0.2.3 NewRelic-Python-OpenCensus/0.1.0`.
+
+## Attributes
+
+The origins of telemetry exported to New Relic needs to be identifiable in order for it to be useful.
+Being able to identify what generated, measured, collected, and transmitted telemetry to New Relic is essential to providing a curated customer experience.
+This section describes the attributes are used to identify these dimensions of the telemetry origins.
+
+The following table is an overview for quick reference all the attributes defined in the following sub-sections.
+
+| Attribute | REQUIRED/RECOMMENDED/OPTIONAL |
+| --------- | ----------------------------- |
+| `instrumentation.provider` | REQUIRED |
+| `instrumentation.name` | RECOMMENDED |
+| `instrumentation.version` | RECOMMENDED |
+| `collector.name` | RECOMMENDED |
+| `collector.version` | RECOMMENDED |
+| `host.hostname` | REQUIRED† |
+| `service.name` | REQUIRED† |
+| `app.name` | REQUIRED† |
+| `db.name` | REQUIRED† |
+
+†: REQUIRED only if annotating an applicable telemetry source.
+See the related sub-section for more information.
+
+### Instrumentation
+
+Instrumentation is the toolset used to measure telemetry.
+This instrumentation usually comes in the form of a library of code, platform, or coding language builtin and provides different instruments to measure the state of a computer program.
+This instrumentation is from what the exporter exports.
+
+Including attributes to identify not only what instrumentation is used but also what code is being instrumented is crucial for interoperability between exporters and the New Relic platform.
+
+#### `instrumentation.provider`
+
+All exported telemetry MUST contain an `instrumentation.provider` attribute that identifies the provider of instrumentation.
+
+Example values of this attribute are:
+
+* `newRelic`
+* `prometheus`
+* `dropwizard`
+* `opencensus`
+* `opentelemetry`
+
+#### `instrumentation.name`
+
+All exported telemetry SHOULD contain an `instrumentation.name` attribute that identifies the code that is being instrumented.
+This would be the framework, library, or application that uses the instrumentation to report telemetry.
+
+Example values of this attribute are:
+
+* `spring-framework`
+* `python-twisted`
+* `gorilla/mux`
+
+#### `instrumentation.version`
+
+All exported telemetry SHOULD contain an `instrumentation.version` attribute that identifies the version of the instrumentation.
+This will be defined by the instrumentation provider.
+
+Example values of this attribute are:
+
+* `v0.1.0`
+* `3`
+* `alpha-v1`
+
+### Collector
+
+Telemetry sent to New Relic is often produced by many collocated sources.
+Given the close proximity these telemetry sources can have, it can be advantageous to unify the transmission of this telemetry to New Relic.
+This reduces network overhead and can simplify the design of system architectures.
+
+Being able to backtrack identity what collector was the ultimate transmitter of telemetry to New Relic is often useful.
+It can help debug issues and provide context of data flows.
+The following attributes are used to make this identification possible.
+
+#### `collector.name`
+
+All exported telemetry SHOULD contain an `collector.name` attribute that identifies the name of the code that collected the telemetry.
+This value SHOULD be overwritten if telemetry is proxied.
+Otherwise, this will be the exporter name.
+
+Example values of this attribute are:
+
+* `newrelic-dropwizard-reporter`
+* `newrelic-opentelemetry-go-exporter`
+
+#### `collector.version`
+
+All exported telemetry SHOULD contain an `collector.version` attribute that identifies the version of the collector.
+This value SHOULD be overwritten if telemetry is proxied.
+Otherwise, this will be the exporter version.
+
+Example values of this attribute are:
+
+* `v0.1.0`
+* `3`
+* `1.0`
+
+### Source Kind
+
+Clearly identifying what kind of system produced the telemetry sent to New Relic is crucial to do.
+A core feature New Relic offers customers is a curated observability experience and it is not possible to provide this without this identification.
+
+The following attributes are used to identify the kind of system for which an exporter exports telemetry.
+All exported telemetry MUST include at least one of the following attributes and MAY include more than one.
+
+#### `host.hostname`
+
+All telemetry exported for a host system running an application MUST contain a `host.hostname` attribute that uniquely identifies that host.
+Other kinds of telemetry exported MAY also contain this attribute as this can be helpful to describe the telemetry origin.
+
+#### `service.name`
+
+All telemetry exported for a generic computer program MUST contain a `service.name` attribute that identifies the name of the program.
+
+#### `app.name`
+
+All telemetry exported for a mobile or browser application MUST contain an `app.name` attribute that identifies the application.
+
+##### `device.model`
+
+All telemetry exported for a mobile application MUST contain an `device.model` attribute that identifies the mobile device model.
+
+#### `db.name`
+
+All telemetry exported for a database MUST contain an `db.name` attribute that identifies the database name.

--- a/Common.md
+++ b/Common.md
@@ -66,7 +66,7 @@ The following table is an overview for quick reference of all the attributes def
 | `browserApp.name` | REQUIRED† |
 | `db.name` | REQUIRED† |
 
-†: applies only if annotating an applicable telemetry source.
+†: applies only if annotating an applicable source.
 See the related sub-section for more information.
 
 ### Instrumentation

--- a/Common.md
+++ b/Common.md
@@ -126,7 +126,7 @@ The following attributes are used to make this identification possible.
 
 #### `collector.name`
 
-If the exporter is transmitting to New Relic directly than all exported measurements SHOULD contain a `collector.name` attribute set to the name of the exporter, otherwise it SHOULD be omitted.
+If the exporter is transmitting to New Relic directly then all exported measurements SHOULD contain a `collector.name` attribute set to the name of the exporter, otherwise it SHOULD be omitted.
 
 Example values of this attribute are:
 
@@ -135,7 +135,7 @@ Example values of this attribute are:
 
 #### `collector.version`
 
-If the exporter is transmitting to New Relic directly than all exported measurements SHOULD contain a `collector.version` attribute set to the version of the exporter, otherwise it SHOULD be omitted.
+If the exporter is transmitting to New Relic directly then all exported measurements SHOULD contain a `collector.version` attribute set to the version of the exporter, otherwise it SHOULD be omitted.
 
 Example values of this attribute are:
 

--- a/Guidelines.md
+++ b/Guidelines.md
@@ -28,14 +28,8 @@ In general, dots are used to separate modifiers and subjects. For example, if yo
 represents, you might call that attribute `histogram.bucket`.
 * When generating groups of metrics that should be visualized together, the metric names for that group SHOULD be the customer-provided metric named, suffixed with name for the type of group, separated by a `.`.
   For example, if you are generating a set of gauges that represent a histogram, you would suffix the customer-provided metric name with "`.buckets`".
-
-### Common patterns:
 * All metric names SHOULD start with the customer-provided metric name that the metric library provides to the exporter.
 * All metrics that share a common name MUST also have at least one variable attribute, so they can be independently aggregated by the back end.
-* All generated metrics/spans SHOULD include an attribute `instrumentation.provider` which identifies the source of the telemetry (for example, "dropwizard" or "prometheus")
-* All generated metrics/spans SHOULD include (if applicable) an attribute `instrumentation.name` which identifies what is being instrumented. (for example, "spring-framework" or "python-twisted")
-* All generated metrics/spans SHOULD include (in applicable) an attribute `instrumentation.version` which identifies the version of the instrumentation that generated the telemetry.
-* All generated metrics/spans SHOULD include an attribute `collector.name`, which identifies the particular exporter in question (for example, "newrelic-dropwizard-reporter", or "newrelic-opentelemetry-exporter")
 
 ### Simple types modeled with a single New Relic metric:
 #### Cumulative Counter

--- a/Guidelines.md
+++ b/Guidelines.md
@@ -28,7 +28,7 @@ In general, dots are used to separate modifiers and subjects. For example, if yo
 represents, you might call that attribute `histogram.bucket`.
 * When generating groups of metrics that should be visualized together, the metric names for that group SHOULD be the customer-provided metric named, suffixed with name for the type of group, separated by a `.`.
   For example, if you are generating a set of gauges that represent a histogram, you would suffix the customer-provided metric name with "`.buckets`".
-* All metric names SHOULD start with the customer-provided metric name that the metric library provides to the exporter.
+* All metric names SHOULD start with the instrumentation-provided or customer-provided metric name that the metric library provides to the exporter.
 * All metrics that share a common name MUST also have at least one variable attribute, so they can be independently aggregated by the back end.
 
 ### Simple types modeled with a single New Relic metric:


### PR DESCRIPTION
Move the normative guidelines around common attributes for all telemetry an exporter exports to the Common.md file.

Update the normative specification of common attributes for all telemetry an exporter exports.

Add normative specification for `collector.version`, `service.name`, `host.hostname`, `app.name`, and `db.name`.