### PR TITLE
Send OTel span status

### DIFF
--- a/opentelemetry/OpenTelemetry-Spans.md
+++ b/opentelemetry/OpenTelemetry-Spans.md
@@ -9,9 +9,10 @@ Here is the process:
 1. For `"instrumentation.provider"`, use `"opentelemetry"`
 1. Assign the span name, span id, parent span id (if present) and trace id to the New Relic span.
 1. Take all OpenTelemetry span attributes, and map them directly over to New Relic span attributes.
-1. If the OpenTelemetry span has a `status` that is `Error`, add an `"error.message"` attribute that
-contains the status description. If no status description is available, set `"error.message"`
-to "Unspecified error".
+1. The OpenTelemetry span status is comprised of a status code and optional description. The status
+code is `Unset`, `Ok`, or `Error`. If the status code is `Ok` or `Error` then add an `otel.status_code`
+attribute and set it to the value of the status code. If the status has a description then add an
+`otel.status_description` attribute and set it to the value of the description.
 1. If there is a Resource associated with the Span, take all of the Resource's labels and add them as
 span attributes.
 1. If there is instrumentation library information associated with the span,

--- a/opentelemetry/OpenTelemetry-Spans.md
+++ b/opentelemetry/OpenTelemetry-Spans.md
@@ -11,7 +11,7 @@ Here is the process:
 1. Take all OpenTelemetry span attributes, and map them directly over to New Relic span attributes.
 1. The OpenTelemetry span status is comprised of a status code and optional description. The status
 code is `Unset`, `Ok`, or `Error`. If the status code is not `Unset`, then add an `otel.status_code`
-attribute and set it to the value of the status code. If the status has a description then add an
+attribute and set it to the value of the status code. If the status code is not `Unset` and the status has a description then add an
 `otel.status_description` attribute and set it to the value of the description.
 1. If there is a Resource associated with the Span, take all of the Resource's labels and add them as
 span attributes.

--- a/opentelemetry/OpenTelemetry-Spans.md
+++ b/opentelemetry/OpenTelemetry-Spans.md
@@ -10,7 +10,7 @@ Here is the process:
 1. Assign the span name, span id, parent span id (if present) and trace id to the New Relic span.
 1. Take all OpenTelemetry span attributes, and map them directly over to New Relic span attributes.
 1. The OpenTelemetry span status is comprised of a status code and optional description. The status
-code is `Unset`, `Ok`, or `Error`. If the status code is `Ok` or `Error` then add an `otel.status_code`
+code is `Unset`, `Ok`, or `Error`. If the status code is not `Unset`, then add an `otel.status_code`
 attribute and set it to the value of the status code. If the status has a description then add an
 `otel.status_description` attribute and set it to the value of the description.
 1. If there is a Resource associated with the Span, take all of the Resource's labels and add them as

--- a/opentelemetry/OpenTelemetry-Spans.md
+++ b/opentelemetry/OpenTelemetry-Spans.md
@@ -9,8 +9,9 @@ Here is the process:
 1. For `"instrumentation.provider"`, use `"opentelemetry"`
 1. Assign the span name, span id, parent span id (if present) and trace id to the New Relic span.
 1. Take all OpenTelemetry span attributes, and map them directly over to New Relic span attributes.
-1. If the OpenTelemetry span has a `status` that is not `OK`, and there is a status description available,
-add an `"error.message"` attribute that contains the status description.
+1. If the OpenTelemetry span has a `status` that is `Error`, add an `"error.message"` attribute that
+contains the status description. If no status description is available, set `"error.message"`
+to "Unspecified error".
 1. If there is a Resource associated with the Span, take all of the Resource's labels and add them as
 span attributes.
 1. If there is instrumentation library information associated with the span,


### PR DESCRIPTION
OpenTelemetry specification now defines three span statuses: Unset, Ok, and Error. See: https://github.com/open-telemetry/opentelemetry-specification/blob/e4d934945f6683097d3bfd3400039010ce90a4b1/specification/trace/api.md#set-status.

It is no longer correct to say "If the OpenTelemetry span has a `status` that is not `OK` ... add an `"error.message"` attribute" because the default status is `Unset` and will often be the resultant status of spans created by instrumentation.

This PR proposes sending up the OTel span's status as attributes. The backend would need to be changed to support these new attributes.

@a-feld @justinfoote I believe the SpanTransactionTransformer could be modified to identify spans with a status of `Error` and then fabricate an `error.message` attribute based on the status description if available. This would allow our exporters to be less smart.