### PR TITLE
Clarify which name to use for service.name

### DIFF
--- a/opentelemetry/OpenTelemetry-Spans.md
+++ b/opentelemetry/OpenTelemetry-Spans.md
@@ -11,7 +11,8 @@ Here is the process:
 1. Take all OpenTelemetry span attributes, and map them directly over to New Relic span attributes.
 1. If the OpenTelemetry span has a `status` that is not `OK`, and there is a status description available,
 add an `"error.message"` attribute that contains the status description.
-1. If there is a Resource associated with the Span, take all of the Resource's labels and add them as
-span attributes.
+1. If there is a Resource associated with the Span, take all of the Resource's attributes and add them as
+span attributes. One exception is the `service.name` attribute, if the exporter has been configured with a
+service name, then this name should take precedence over the `service.name` attribute on the resource.
 1. If there is instrumentation library information associated with the span,
 add the corresponding `"instrumentation.name"` and `"instrumentation.version"` attributes to the span, if non-empty.


### PR DESCRIPTION
Both OTel Resources and New Relic exporters define a service name. The purpose of this PR is to pose the question: which one should we use? I took a stab at a potential answer.