### PR TITLE
Clarify conflict handling for attributes

### DIFF
--- a/opentelemetry/OpenTelemetry-Spans.md
+++ b/opentelemetry/OpenTelemetry-Spans.md
@@ -8,7 +8,7 @@ Here is the process:
 1. For the `"collector.name"` attribute, use `"newrelic-opentelemetry-exporter"`
 1. For `"instrumentation.provider"`, use `"opentelemetry"`
 1. Assign the span name, span id, parent span id (if present) and trace id to the New Relic span.
-1. Take all OpenTelemetry span attributes, and map them directly over to New Relic span attributes.
+1. Take all OpenTelemetry span attributes, and map them directly over to New Relic span attributes. OpenTelemetry span attributes that have the same name as the attributes called out in this spec should not be mapped over to the New Relic span.
 1. The OpenTelemetry span status is comprised of a status code and optional description. The status
 code is `Unset`, `Ok`, or `Error`. If the status code is not `Unset`, then add an `otel.status_code`
 attribute and set it to the value of the status code. If the status code is not `Unset` and the status has a description then add an


### PR DESCRIPTION
The intent of this change is clarify how conflicts between OTel span attributes and New Relic span attributes should be handled. 

The current proposal is that the special New Relic attributes should take precedence over any attributes defined in the OTel span attributes. The special New Relic attributes typically drive some sort of business or UI logic, and an "arbitrary" value for an attribute of the same name defined in the OTel attributes could lead to a problem.